### PR TITLE
Fixed issue reading PRFL-file

### DIFF
--- a/src/pydra_core/location/profile/profile.py
+++ b/src/pydra_core/location/profile/profile.py
@@ -689,18 +689,22 @@ class Profile:
         # Create a new profile
         profile = cls(profile_name)
 
-        # Version
-        version = float([entry for entry in prfl if "versie" in entry][0].split(" ")[1])
+        # Get version
+        version_lines = [line for line in prfl if "versie" in line]
+        if version_lines.__len__() != 1:
+            raise ValueError(f"[ERROR] PRFL-file should only contain 1 VERSIE-line. Counted {version_lines.__len__()}.")
+        version_line: str = version_lines[0].split(" ")[-1]
+        version = float(version_line)
         if version != 4.0:
             raise NotImplementedError(f"[ERROR] Prfl version {version} is not supported.")
 
         # Sheet pile
-        sheetpile = True if float([entry for entry in prfl if "damwand" in entry][0].split(" ")[1]) == 1.0 else False
+        sheetpile = True if float([entry for entry in prfl if "damwand" in entry][0].split(" ")[-1]) == 1.0 else False
         if sheetpile:
             raise NotImplementedError("[ERROR] Sheet piles are not implemented.")
 
         # Breakwater
-        breakwater = Breakwater(int([entry for entry in prfl if "dam" in entry][0].split(" ")[1]))
+        breakwater = Breakwater(int([entry for entry in prfl if "dam" in entry][0].split(" ")[-1]))
         breakwater_level = float([entry for entry in prfl if "damhoogte" in entry][0].split(" ")[1])
         profile.set_breakwater(breakwater, breakwater_level)
 


### PR DESCRIPTION
In `Profile.from_prfl()` zat een bug. Bij het uitlezen van het versie nummer anticipeert hij niet dat er meer white space kan zijn. Ik heb het nu aangepast. Vervolgens trad hetzelfde probleem op bij damwand en dam. Maar ik denk dat het nog wel op meer plekken verbeterd moet worden. 

Kwam de bug tegen bij dit PRFL-bestand. Is door een collega van jullie gegenereerd op een project van ons. 
[AW155.+206.txt](https://github.com/user-attachments/files/29848820/AW155.%2B206.txt)

Tips:
- De method is met bijna 100 regels vrij lang. Het is overzichtelijker dit op te splitsen naar een nieuw Python-bestand. 
- Combineer chaining niet met een overlappende functie. Dat maakt het minder navolgbaar. Programmeer in volgorde van hoe het uitgevoerd wordt. 

```
overlappende_functie(my.chain.of.other.functions.that.are.exectuted.earlier()
``` 